### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-terrain
+  namespace: reearth
+  description: Open terrain tiles for 3D globes
+  annotations:
+    github.com/project-slug: reearth/reearth-terrain
+  links:
+  - url: https://github.com/reearth/reearth-terrain
+    title: GitHub
+    icon: github
+  - url: https://terrain.reearth.land
+    title: Website
+    icon: web
+  tags:
+  - typescript
+  - 3d
+  - geoid
+  - gis
+  - terrain
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cto-office


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-terrain` (namespace `reearth`)
- **Owner:** `reearth/cto-office`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.